### PR TITLE
Fix: 2bd31854c3b4 (dmidecode: Add support for large cache sizes)

### DIFF
--- a/dmidecode.c
+++ b/dmidecode.c
@@ -1569,6 +1569,8 @@ static void dmi_cache_size_2(u32 code)
 		else
 			printf(" %u kB", code << 6);
 	}
+	else if (code & 0x8000)
+                printf(" %u kB", (code & 0x7FFF) << 6);
 	else
 		printf(" %u kB", code);
 }


### PR DESCRIPTION
For Lenovo machine(e.g. Lenovo THINKSYSTEM SD530), dmidecode will print
incorrect cache information, for example:
 #dmidecode -t 7
 Handle 0x0048, DMI type 7, 27 bytes
 Cache Information
        Socket Designation: L3-Cache
        Configuration: Enabled, Not Socketed, Level 3
        Operational Mode: Varies With Memory Address
        Location: Internal
        Installed Size: 33296 kB
        Maximum Size: 33296 kB

Acutally, the values of "Installed Size" and "Maximum Size" are 33792 kB.
It does not cover this case, so this patch will fix this issue.

Signed-off-by: Lianbo Jiang <lijiang@redhat.com>