### PR TITLE
in some bios,the dmiheader length is always 0x1B,so the cache info is…

### DIFF
--- a/dmidecode.c
+++ b/dmidecode.c
@@ -4262,11 +4262,11 @@ static void dmi_decode(const struct dmi_header *h, u16 ver)
 				dmi_cache_mode((WORD(data + 0x05) >> 8) & 0x0003));
 			pr_attr("Location", "%s",
 				dmi_cache_location((WORD(data + 0x05) >> 5) & 0x0003));
-			if (h->length >= 0x1B)
+			if (h->length >= 0x1B && 0xFFFF==WORD(data + 0x09))
 				dmi_cache_size_2("Installed Size", DWORD(data + 0x17));
 			else
 				dmi_cache_size("Installed Size", WORD(data + 0x09));
-			if (h->length >= 0x17)
+			if (h->length >= 0x17 && 0xFFFF==WORD(data + 0x07))
 				dmi_cache_size_2("Maximum Size", DWORD(data + 0x13));
 			else
 				dmi_cache_size("Maximum Size", WORD(data + 0x07));


### PR DESCRIPTION
… wrong.in paper "smibois3.1.0":7.8 Cache Infomation,For Cache sizes greater than 2047 MB, theMaximum Cache Size field is set to 0xFFFF,so add this condition to juge if cache size is greater than 2047MB

Signed-off-by: guozhijun <guozhijun@uniontech.com>