### PR TITLE
add chassis information type ‘Computer’ for alpha architecture

### DIFF
--- a/dmidecode.c
+++ b/dmidecode.c
@@ -626,7 +626,8 @@ static const char *dmi_chassis_type(u8 code)
 		"IoT Gateway",
 		"Embedded PC",
 		"Mini PC",
-		"Stick PC" /* 0x24 */
+		"Stick PC",
+		"Computer" /* 0x25 */
 	};
 
 	code &= 0x7F; /* bits 6:0 are chassis type, 7th bit is the lock bit */

--- a/dmidecode.c
+++ b/dmidecode.c
@@ -2535,7 +2535,8 @@ static const char *dmi_memory_array_use(u8 code)
 		"Video Memory",
 		"Flash Memory",
 		"Non-volatile RAM",
-		"Cache Memory" /* 0x07 */
+		"Cache Memory",
+		"System memory" /* 0x08 */
 	};
 
 	if (code >= 0x01 && code <= 0x07)


### PR DESCRIPTION
add chassis information type ‘Computer’ for alpha architecture